### PR TITLE
Remove `crash_handler` and `update_installer` by default

### DIFF
--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -18,6 +18,7 @@
         }
     },
     "post_install": [
+        "'crash_handler', 'update_installer' | ForEach-Object { Remove-Item -Force \"$dir\\$_.exe\" }",
         "$sublimepath = \"$dir\\sublime_text.exe\".Replace('\\', '\\\\')",
         "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\scoop-private\\scripts\\$app\\$_\") {",
@@ -31,7 +32,7 @@
         "}",
         "info 'Cracking . . .'",
         "$sublimepath = \"$dir\\sublime_text.exe\"",
-        "$stream = [System.IO.File]::OpenWrite($sublimepath )",
+        "$stream = [System.IO.File]::OpenWrite($sublimepath)",
         "@'",
         "0x000A0C14: 48 C7 C0 00 00 00 00 C3",
         "0x0000647C: 90 90 90 90 90",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).