### PR TITLE
chore: Use `irm` instead of `iwr` for `sublime-*` `checkver.script`

### DIFF
--- a/bucket/sublime-merge.json
+++ b/bucket/sublime-merge.json
@@ -47,7 +47,7 @@
     "checkver": {
         "script": [
             "$dev_version, $stable_version = ",
-            "     'dev', 'stable' | ForEach-Object { ($(Invoke-WebRequest \"https://www.sublimemerge.com/updates/${_}_update_check\").Content | ConvertFrom-Json).latest_version }",
+            "     'dev', 'stable' | ForEach-Object { (Invoke-RestMethod \"https://www.sublimemerge.com/updates/$_`_update_check\").latest_version }",
             "if ($dev_version -gt $stable_version) { $dev_version } else { $stable_version }"
         ],
         "regex": "(\\d+)"

--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -60,7 +60,7 @@
     "checkver": {
         "script": [
             "$dev_version, $stable_version = ",
-            "     'dev', 'stable' | ForEach-Object { ($(Invoke-WebRequest \"https://www.sublimetext.com/updates/4/${_}_update_check\").Content | ConvertFrom-Json).latest_version }",
+            "     'dev', 'stable' | ForEach-Object { (Invoke-RestMethod \"https://www.sublimetext.com/updates/4/$_`_update_check\").latest_version }",
             "if ($dev_version -gt $stable_version) { $dev_version } else { $stable_version }"
         ],
         "regex": "((\\d)\\d+)",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).