### PR TITLE
sublime-text: Fix trailing comma

### DIFF
--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -48,7 +48,7 @@
         "       $stream.Write($data, 0, $data.Length)",
         "   }",
         "   $stream.Close()",
-        "}",
+        "}"
     ],
     "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
     "bin": "subl.exe",


### PR DESCRIPTION
```
❯ scoop cleanup -g *; scoop cache rm -g *
WARN  Error parsing JSON at '~\scoop\apps\sublime-text\current\manifest.json'.
```
Since I'm assuming you're already a Sublime user, try https://jsoncomma.github.io/jsoncomma/ https://github.com/brian6932/dank-scoop/blob/master/bucket/jsoncomma.json.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).